### PR TITLE
proper include of freetype in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,12 @@ else()
         )
 endif()
 
+# print a summary of build options
+message("Build options:")
+message("- Filter Audio: ${FILTER_AUDIO}")
+message("- Toxcore Static: ${TOXCORE_STATIC}")
+
+
 # include utoxNATIVE dependend on the OS
 if(WIN32)
     add_subdirectory(src/windows)
@@ -49,7 +55,12 @@ elseif(APPLE)
     add_definitions("-x objective-c")
     add_subdirectory(src/cocoa)
 elseif(UNIX)
-    include_directories(/usr/include/freetype2)
+    find_package(Freetype REQUIRED)
+    include_directories(${FREETYPE_INCLUDE_DIRS})
+    message("Found Freetype version ${FREETYPE_VERSION_STRING}")
+    message("Freetype include: ${FREETYPE_INCLUDE_DIRS}")
+    message("Freetype library: ${FREETYPE_LIBRARIES}")
+
     add_subdirectory(src/xlib)
 endif()
 

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -1,9 +1,5 @@
 project(utoxUI LANGUAGES C)
 
-if(UNIX)
-    include_directories(/usr/include/freetype2)
-endif()
-
 add_library(utoxUI STATIC
     button.c
     button.h

--- a/src/xlib/CMakeLists.txt
+++ b/src/xlib/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(utoxNATIVE LANGUAGES C)
 
-include_directories(/usr/include/freetype2)
-
 #########################################
 ## Native Icon data
 #########################################
@@ -35,7 +33,7 @@ add_library(utoxNATIVE STATIC
     filesys.c
     )
 
-target_link_libraries(utoxNATIVE icon v4lconvert X11 Xext Xrender fontconfig freetype resolv dl )
+target_link_libraries(utoxNATIVE icon v4lconvert X11 Xext Xrender fontconfig ${FREETYPE_LIBRARIES} resolv dl )
 
 install(FILES
     ../utox.desktop


### PR DESCRIPTION
learned something new today. CMake has a powerful tool for finding
libraries on different platforms. Instead of hardcoding an include dir,
we can let cmake determine the correct paths and also let it fail with a
proper error (i.e. "freetype librariy is required") instead of cryptic
linker/compiler errors if freetype is not available.

Could be done for more libraries but freetype was the one that needed
special handling so I added it for freetype only for now.

references:
- https://cmake.org/cmake/help/v3.0/module/FindFreetype.html
- http://stackoverflow.com/a/23888557/1106908

This goes into https://github.com/uTox/uTox/pull/575